### PR TITLE
US18 Merchant Invoice Item change

### DIFF
--- a/app/controllers/merchant_invoices_controller.rb
+++ b/app/controllers/merchant_invoices_controller.rb
@@ -5,8 +5,12 @@ class MerchantInvoicesController < ApplicationController
   end
 
   def show
-    # @merchant = Merchant.find(params[:merchant_id])
     @invoice = Invoice.find(params[:invoice_id])
-    # require 'pry';binding.pry
+  end
+
+  def update
+    invoice_item = InvoiceItem.find(params[:in_item_id])
+    invoice_item.update(status: params[:status])
+    redirect_to "/merchants/#{params[:merchant_id]}/invoices/#{params[:invoice_id]}"
   end
 end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -19,6 +19,10 @@
     <td><%= invoice_item.quantity %></td>
     <td><%= number_to_currency(invoice_item.item.unit_price/100.0) %></td>
     <td><%= invoice_item.status %></td>
+    <%= form_with url: "/merchants/#{params[:merchant_id]}/invoices/#{@invoice.id}?in_item_id=#{invoice_item.id}", method: :patch, data: { turbo: false } do |f| %>
+    Current Status: <%= f.select :status, options_for_select(["pending", "packaged", "shipped"], selected: invoice_item.status) %><br>
+    <%= f.submit "Update Item Status" %>
+    <%end%>
   </tr>
 </section>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   get "/merchants/:merchant_id/items/:item_id", to: "merchant_items#show"
   get "/merchants/:merchant_id/invoices", to: "merchant_invoices#index"
   get "/merchants/:merchant_id/invoices/:invoice_id", to: "merchant_invoices#show"
+  patch "/merchants/:merchant_id/invoices/:invoice_id", to: "merchant_invoices#update"
 end
 # namespace: admin do 
 #   resources: merchants, only [index] 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -38,4 +38,20 @@ RSpec.describe "Merchant Invoice Show page" do
     expect(find("#total_revenue")).to have_content("$52.00")
 
   end
+
+  it "can change the status of the merchant invoice item" do
+    load_test_data
+
+    visit "merchants/#{@merchant1.id}/invoices/#{@invoice_1.id}"
+
+    expect(page).to have_field('status', with: 'packaged')
+    expect(page).to_not have_field('status', with: 'shipped')
+
+    select('shipped', from: 'status')
+    click_button "Update Item Status"
+
+    expect(page).to_not have_field('status', with: 'pending')
+    expect(page).to have_field('status', with: 'shipped')
+    # save_and_open_page
+  end
 end


### PR DESCRIPTION
US18

## Description
This PR:
- Adds the option to change the status of a item held by a merchant and invoice
- Uses the Invoice_item status as the status for the item since the item and invoice is unique in that situation
- Includes test for status change

## Type of Change

- [ ] **fix**
- [x] **feat**
- [x] **test**
- [ ] **refactor**
- [ ] **docs**

## Checklist

- [x] **Code has been self reviewed**
- [x] **Code runs without any errors**
- [x] **Thorough testing has been implemented if adding feature**
- [x] **All tests pass**
